### PR TITLE
fix historical and technical inaccuracies in linux intro

### DIFF
--- a/02-linux/intro-linux.es.md
+++ b/02-linux/intro-linux.es.md
@@ -13,13 +13,13 @@ description: >-
 ---
 ## Qué es Linux y su importancia en el mundo de la informática
 
-A pesar de a lo que generalmente puedas escuchar sobre linux, este en realidad se trata de un núcleo o **kernel** que puede controlar a un hardware, una manera más sencilla de explicarlo es que Linux es un conjuntos de drivers necesarios para usar un dispositivo como una computadora o una laptop. Este se creó como un núcleo semejante al de un sistema operativo UNIX.
+A pesar de lo que generalmente se escucha sobre Linux, en realidad se trata de un **kernel** (núcleo) que actúa como intermediario entre el hardware y el software de usuario. De forma simplificada, Linux es el componente que gestiona los recursos del hardware — CPU, memoria, dispositivos — y permite que los programas se ejecuten sobre él. Fue diseñado siguiendo los principios del sistema operativo UNIX.
 
-Este núcleo fue desarrollado con Linus Torvalds cuando en 1991 comenzó a trabajar con unas ideas para un núcleo de un sistema operativo gratuito similar a unix, por lo que tomó como base el sistema Minix como un clon de Unix e hizo un núcleo monolítico y así con ayuda de colaboradores, sacar la primera versión linux 0.01.
+Este núcleo fue desarrollado por Linus Torvalds, quien en 1991 comenzó a trabajar en un núcleo de sistema operativo gratuito inspirado en UNIX. Tomó como referencia MINIX (un sistema educativo creado por Andrew S. Tanenbaum) y desarrolló un núcleo monolítico. Con la ayuda de colaboradores a través de Internet, publicó la primera versión, Linux 0.01.
 
-Actualmente Linux es un núcleo monolítico híbrido con controladores de dispositivos y extensiones del núcleo que normalmente se ejecutan en un espacio privilegiado conocido como anillo 0, con acceso irrestricto al hardware, aunque algunos se ejecutan en espacio de usuario.
+Actualmente Linux es un núcleo monolítico con soporte para módulos cargables. Los controladores de dispositivos y las extensiones del núcleo normalmente se ejecutan en un espacio privilegiado conocido como anillo 0 (*ring 0*), con acceso irrestricto al hardware, aunque algunos controladores pueden ejecutarse en espacio de usuario.
 
-En 1992 los desarrolladores del núcleo Linux, comenzaron a trabajar con el proyecto GNU, desarrollado por Richard Stallman en 1983 y así crear GNU/Linux, una familia de sistemas operativos tipo Unix compuesto por software libre y de código abierto buscando una solución de libre distribución de los sistemas operativos frustrado por la concesión de licencias de uso que utilizaba MINIX.
+En 1992, el núcleo Linux se combinó con las herramientas del proyecto GNU, iniciado por Richard Stallman en 1983. El proyecto GNU buscaba crear un sistema operativo completo de software libre, pero carecía de un núcleo funcional. La unión de ambos proyectos dio lugar a GNU/Linux, una familia de sistemas operativos tipo UNIX compuestos por software libre y de código abierto.
 
 Entre los componentes que tenemos dentro del sistema GNU/Linux podemos conseguir:
 
@@ -31,24 +31,24 @@ Entre los componentes que tenemos dentro del sistema GNU/Linux podemos conseguir
 
 ## Diferencias entre Linux y otros sistemas operativos
 
-Linux a diferencia de Windows, es multitarea real, y multiusuario, posee un esquema de seguridad basado en usuarios y permisos de lectura, escritura y ejecución establecidos a los archivos y directorios. Esto significa que cada usuario es propietario de sus archivos, y otro usuario no puede acceder a estos archivos. Esta propiedad no permite el contagio de virus entre archivos de diferentes usuarios.
+Linux es un sistema multitarea real y multiusuario. Posee un esquema de seguridad basado en usuarios y permisos de lectura, escritura y ejecución asignados a archivos y directorios. Cada usuario es propietario de sus archivos y, por defecto, otros usuarios no pueden acceder a ellos. Este modelo de permisos reduce significativamente la propagación de malware entre cuentas de usuario, aunque no la elimina por completo.
 
 | Característica | Windows | Linux |
 | --- | --- | --- |
-| Tipo de sistema operativo | Comercial (se vende y se compra) | Código abierto, descargable y modificable de forma gratuita |
-| Estabilidad | Poco estable | Más estable |
-| Interfaz gráfica | Alta tecnología pero poco estable | Variedad de interfaces, manejo más complejo |
-| Apto para principiantes | Sí, gracias a interfaces gráficas intuitivas | Más complejo, requiere familiaridad con la línea de comandos |
-| Seguridad | Frecuentes fallos de seguridad y vulnerabilidades | Raramente amenazado por fallos de seguridad |
-| Actualizaciones | Sencillas y automatizadas | En ocasiones pueden ser complejas |
+| Tipo de sistema operativo | Comercial (licencia de pago) | Núcleo de código abierto, distribuciones gratuitas y comerciales |
+| Estabilidad | Estable en versiones recientes (Windows 10/11, Server) | Alta estabilidad, especialmente en servidores |
+| Interfaz gráfica | Interfaz unificada y pulida | Variedad de entornos de escritorio (GNOME, KDE, XFCE, etc.) |
+| Apto para principiantes | Sí, interfaz gráfica intuitiva | Distribuciones como Ubuntu facilitan la entrada, pero el dominio requiere línea de comandos |
+| Seguridad | Modelo de permisos mejorado desde Vista/UAC; mayor superficie de ataque por cuota de mercado | Modelo de permisos robusto por defecto; menor superficie de ataque en escritorio, no invulnerable |
+| Actualizaciones | Automatizadas vía Windows Update | Gestores de paquetes potentes (`apt`, `dnf`, `pacman`), actualizaciones controladas por el usuario |
 
 ### Ventajas y beneficios de utilizar Linux
 
 El hecho de que es *software libre*, es decir, que junto con el sistema, se puede obtener el código fuente de cualquier parte del mismo y modificarlo a gusto. Ésto da varias ventajas, por ejemplo:
 
-- La seguridad de saber *qué hace* un programa tan solo viendo el código fuente, o en su defecto, tener la seguridad que al estar el código disponible,
-- La libertad que provee la licencia GPL permite a cualquier programador modificar y mejorar cualquier parte del sistema, ésto da como resultado que la calidad del software incluido en GNU/Linux sea muy buena.
-- El hecho de que el sistema sea mantenido por una gran comunidad de programadores y usuarios alrededor del mundo, provee una gran velocidad de respuesta ante errores de programas que se van descubriendo, que ninguna compañía comercial de software puede igualar.
+- La posibilidad de auditar *qué hace* un programa inspeccionando su código fuente, lo que aumenta la transparencia y la confianza en el software.
+- La licencia GPL permite a cualquier desarrollador modificar y mejorar cualquier parte del sistema, lo que contribuye a una alta calidad del software incluido en GNU/Linux.
+- El mantenimiento por una gran comunidad de programadores y usuarios alrededor del mundo permite una respuesta rápida ante errores y vulnerabilidades descubiertos.
 
 Además de las ventajas anteriormente enumeradas, GNU/Linux es ideal para su utilización en un ambiente de trabajo, dos razones justifican esto:
 


### PR DESCRIPTION
## What

- Corrects historical details about Linus Torvalds and the GNU+Linux merge (dates, roles, motivations).
- Replaces biased/incorrect claims in the Windows vs Linux comparison table (e.g. "Windows poco estable", "Linux raramente amenazado") with objective, accurate statements.
- Fixes the claim that Linux's permission model "does not allow virus contagion" — replaced with a nuanced explanation.

## Why

The original text contained factual errors (e.g. "kernel monolítico híbrido" is inaccurate for Linux), misleading comparisons (modern Windows is stable, Linux is not immune to malware), and an incomplete sentence in the advantages section. Students learning cybersecurity need technically precise material to build correct mental models.

## Out of scope

- Other files in the `02-linux` module (addressed in separate PRs).
- English `.md` sibling file.

## File(s)

- `02-linux/intro-linux.es.md`