### PR TITLE
fix missing space and period in network planning intro

### DIFF
--- a/01-fundamentos-redes/network-planning-and-documentation.es.md
+++ b/01-fundamentos-redes/network-planning-and-documentation.es.md
@@ -11,7 +11,7 @@ description: >-
   eficiencia. Descubre estrategias clave y mejores prácticas para optimizar tu
   red.
 ---
-La planificación y documentación de redes es un proceso esencial para garantizar el diseño, implementación y mantenimiento efectivo de una red. Consiste en la creación de un plan estratégico que define los objetivos, requisitos y recursos necesarios para construir y gestionar una red de manera eficiente y segura esoimplica identificar las necesidades específicas de la organización, como el número de usuarios, los servicios requeridos y el volumen de tráfico esperado. También implica evaluar las tecnologías disponibles y seleccionar las más adecuadas para satisfacer las necesidades de la red.
+La planificación y documentación de redes es un proceso esencial para garantizar el diseño, implementación y mantenimiento efectivo de una red. Consiste en la creación de un plan estratégico que define los objetivos, requisitos y recursos necesarios para construir y gestionar una red de manera eficiente y segura. Eso implica identificar las necesidades específicas de la organización, como el número de usuarios, los servicios requeridos y el volumen de tráfico esperado. También implica evaluar las tecnologías disponibles y seleccionar las más adecuadas para satisfacer las necesidades de la red.
 
 ### **Documentación de red: diagramas, inventario de equipos**
 


### PR DESCRIPTION
## What

- Fix "esoimplica" → "eso implica" (missing space and period between sentences) in the introductory paragraph.

## Why

Two sentences were fused together without punctuation or spacing, making the paragraph difficult to read.

## Out of scope

- Invalid IPs in config tables (separate PR #162).
- English frontmatter (separate cross-file PR).

## File(s)

- `01-fundamentos-redes/network-planning-and-documentation.es.md`