### PR TITLE
translate English frontmatter to Spanish across module files

### DIFF
--- a/01-fundamentos-redes/basic-network-security.es.md
+++ b/01-fundamentos-redes/basic-network-security.es.md
@@ -1,13 +1,15 @@
 ---
-title: Basic Network Security
+title: Seguridad básica de redes
 tags:
-  - networks
+  - redes
+  - ciberseguridad
 authors:
   - blindma1den
   - lorenagubaira
 description: >-
-  Learn the essentials of basic network security! Discover how firewalls protect
-  against unauthorized access and DDoS attacks. Strengthen your network today!
+  Aprende los fundamentos de la seguridad de redes. Descubre cómo los firewalls
+  protegen contra accesos no autorizados y ataques DDoS, y conoce los
+  protocolos de cifrado WiFi (WEP, WPA, WPA2, WPA3).
 ---
 ## Que es un Firewall
 

--- a/01-fundamentos-redes/ip-address-management.es.md
+++ b/01-fundamentos-redes/ip-address-management.es.md
@@ -7,8 +7,8 @@ authors:
   - blindma1den
   - lorenagubaira
 description: >-
-  Master IP Address Management and enhance your network security skills. Learn
-  about IPv4, IPv6, and subnetting. Discover essential strategies now!
+  Domina la gestión de direcciones IP y mejora tus habilidades en seguridad de
+  redes. Aprende sobre IPv4, IPv6 y subnetting.
 ---
 Es fundamental que un profesional de redes y ciberseguridad sepa gestionar direcciones IP debido a que las direcciones IP son elementos esenciales en la infraestructura de cualquier red, y desempeñan un papel crítico en la ciberseguridad.
 

--- a/01-fundamentos-redes/network-planning-and-documentation.es.md
+++ b/01-fundamentos-redes/network-planning-and-documentation.es.md
@@ -7,7 +7,7 @@ authors:
   - blindma1den
   - lorenagubaira
 description: >-
-  Master la planificación y documentación de redes para lograr escalabilidad y
+  Domina la planificación y documentación de redes para lograr escalabilidad y
   eficiencia. Descubre estrategias clave y mejores prácticas para optimizar tu
   red.
 ---

--- a/01-fundamentos-redes/network-troubleshooting.es.md
+++ b/01-fundamentos-redes/network-troubleshooting.es.md
@@ -6,8 +6,8 @@ authors:
   - blindma1den
   - lorenagubaira
 description: >-
-  Master la solución de problemas de red con herramientas de diagnóstico y
-  monitoreo. Descubre cómo optimizar el rendimiento y asegurar tu red hoy.
+  Domina la solución de problemas de red con herramientas de diagnóstico y
+  monitoreo. Descubre cómo optimizar el rendimiento y asegurar tu red.
 
 ---
 A veces podemos tener problemas de rendimiento en nuestra red y es necesario saber la razón para así poder tomar los correctivos. Para ello tenemos herramientas que pueden realizar un diagnóstico de red.

--- a/01-fundamentos-redes/networking-virtualbox.es.md
+++ b/01-fundamentos-redes/networking-virtualbox.es.md
@@ -6,8 +6,8 @@ tags:
 authors:
   - arnaldoperez
 description: >-
-  Discover how to set up and manage networks in VirtualBox! Learn about NAT,
-  Bridged, and Host-Only connections for your virtual machines.
+  Aprende a configurar y gestionar redes en VirtualBox. Conoce las conexiones
+  NAT, Bridged y Host-Only para tus máquinas virtuales.
 ---
 ## Interfaces Virtuales
 


### PR DESCRIPTION
## What

Translate frontmatter metadata (title, tags, description) from English to Spanish in 5 `.es.md` files that had English or mixed-language frontmatter:

- `basic-network-security.es.md`: title, tags, and description were entirely in English.
- `ip-address-management.es.md`: description was in English.
- `network-planning-and-documentation.es.md`: description started with English "Master".
- `network-troubleshooting.es.md`: description started with English "Master".
- `networking-virtualbox.es.md`: description was entirely in English.

## Why

Frontmatter metadata is used by the learning platform for SEO, search, and course navigation. English metadata in `.es.md` files breaks the Spanish-language student experience — search results show English descriptions for Spanish content, and the platform may display mismatched language in course listings. Each file gets its own atomic commit for clean git history.

## Out of scope

- Content changes within the files (handled in separate PRs).

## File(s)

- `01-fundamentos-redes/basic-network-security.es.md`
- `01-fundamentos-redes/ip-address-management.es.md`
- `01-fundamentos-redes/network-planning-and-documentation.es.md`
- `01-fundamentos-redes/network-troubleshooting.es.md`
- `01-fundamentos-redes/networking-virtualbox.es.md`