### PR TITLE
docs(linux): review linux module content

### DIFF
--- a/02-linux/basic-system-administration.es.md
+++ b/02-linux/basic-system-administration.es.md
@@ -10,9 +10,9 @@ description: >-
   usuarios, grupos y optimizar la seguridad. ¡Descubre cómo mejorar tu sistema
   ahora!
 ---
-## Gestion de grupos y usuario
+## Gestión de grupos y usuarios
 
-Podemos denominar a Linux como un sistema operativo multiusuario, donde existen dos tipos de usuarios, el usuario root o administrador, y el resto de los usuario
+Podemos denominar a Linux como un sistema operativo multiusuario, donde existen dos tipos de usuarios: el usuario root o administrador, y el resto de los usuarios.
 
 El usuario root tiene la posibilidad de realizar todo tipo de labores respecto a la administración del sistema. Los cambios o modificaciones realizados con este usuario pueden causar inconvenientes en la seguridad del sistema completo, por lo que debemos tener en cuenta recomendaciones como utilizar este root solo cuando sea estrictamente necesario llevar a cabo una tarea de administración, y cuando terminemos, debemos volver a trabajar con nuestro usuario normal. Además, se sugiere que para acceder al usuario administrador, primero se haya iniciado sesión a través de una cuenta de usuario normal, esta medida previene trabajar con root de manera predeterminada.
 
@@ -40,17 +40,19 @@ Algunos comandos que podemos usar para la gestión de usuarios y grupos son
 
 Una de las ventajas de la configuración de red y conexión en linux es que fácilmente se puede hacer a través desde la terminal con varios comandos, veamos cuales son:
 
-- Si queremos saber si como esta configurada la **red TCP/IP** podemos usar el comando `ifconfig` o con `ip add`
+- Para consultar la configuración de la **red TCP/IP** usamos el comando `ip addr` (o su forma abreviada `ip a`). El comando `ifconfig` está deprecado en la mayoría de distribuciones modernas y ha sido sustituido por la suite `iproute2`.
 
-La respuesta del comando nos mostrara la ip de la máquina (inet), mascara de red (netmask) y dirección de difusión (broadcast).
+La respuesta del comando mostrará la dirección IP de la máquina (`inet`), la máscara de red en formato CIDR y la dirección de difusión (`brd`).
 
-- Si queremos cambiar la dirección de ip, usaremos el mismo comando `ifconfig`:
+- Para cambiar la dirección IP de una interfaz, usamos el comando `ip`:
 
 ```bash
-ifconfig eth0 192.168.1.100 netmask 255.255.255.0 broadcast 192.168.1.255
+sudo ip addr add 192.168.1.100/24 broadcast 192.168.1.255 dev eth0
 ```
 
-**`eth0`** es la interfaz de red que vamos a configurar
+> **Nota:** `ifconfig` aún puede estar disponible instalando el paquete `net-tools`, pero se recomienda usar `ip` en su lugar.
+
+**`eth0`** es la interfaz de red que vamos a configurar (en distribuciones modernas puede aparecer como `enp0s3`, `ens33`, etc.).
 
 - El comando `ping` nos sirve de mucha utilidad para medir la latencia y la conectividad de la red. A través de este comando se mandan paquetes de datos a la dirección puesta en el comando esperando por respuesta de dicha dirección.
 
@@ -64,7 +66,7 @@ Haciendo ping a dirección_ip con 32 bytes de datos:
 
 Respuesta desde 127.0.0.1: bytes=32 tiempo= <10 ms TTL=128
 
-> 💡 TTL= es el tiempo de vida del paquete enviado y su valor óptimo es 128
+> **TTL** (*Time To Live*) indica el número máximo de saltos (routers) que un paquete puede atravesar antes de ser descartado. Su valor inicial depende del sistema operativo de origen: 64 en Linux, 128 en Windows, 255 en algunos equipos de red. No existe un valor "óptimo" universal.
 
 **Netstat** es otra herramienta que podemos utilizar a través de la línea de comandos. Nos permite monitorizar las redes y también poder solucionar determinados problemas que puedan surgir.
 

--- a/02-linux/command-line-fundamentals.es.md
+++ b/02-linux/command-line-fundamentals.es.md
@@ -28,7 +28,7 @@ Al ingresar la orden con la tecla 'Intro', el intérprete analiza la secuencia d
 
 La interfaz de línea de comandos o interfaz de línea de órdenes (CLI) es un tipo de interfaz de usuario de computadora que permite a los usuarios dar instrucciones a algún programa informático o al sistema operativo por medio de una línea de texto simple
 
-Las CLI pueden emplearse interactivamente, escribiendo instrucciones en alguna especie de entrada de texto, o pueden utilizarse de una forma mucho más automatizada, leyendo órdenes desde un archivo de [Scripts](https://es.wikipedia.org/wiki/Script)scripts.
+Las CLI pueden emplearse interactivamente, escribiendo instrucciones en alguna especie de entrada de texto, o pueden utilizarse de una forma mucho más automatizada, leyendo órdenes desde un archivo de [scripts](https://es.wikipedia.org/wiki/Script).
 
 Algunas Shells CLI que frecuentemente conseguimos son:
 
@@ -39,47 +39,41 @@ Algunas Shells CLI que frecuentemente conseguimos son:
 
 ## Comandos básicos de navegación y manipulación de archivos y directorios
 
-Estos son varios comandos basicos que lo ayudaran a navegar en la terminal. 
+Estos son varios comandos básicos que te ayudarán a navegar en la terminal.
 
-Las flags son una manera de pasarle opciones a los comandos y asi tener algun resultado mas especifico a lo que estamos buscando.
+Las *flags* son opciones que se pasan a los comandos para obtener un resultado más específico.
 
 | Comando | Flags | Función |
 | --- | --- | --- |
-| pwd |  | Imprime el directorio  actual de trabajo |
-| cd |  | Cambiar el directorio de trabajo |
-| ls |  | Listar contenido del directorio |
-|  | -R | Listara todos los archivos dentro de los subdirectorios |
-|  | -a | Mostrará todos los archivos ocultos |
-|  | -al | Mostrará la información detallada de los archivos y directorios |
-| find |  | Buscará archivos dentro de un directorio en especifico |
-|  | -iname | Buscará archivos por el nombre o extension en el directorio |
-|  | -type | Buscará archivos por el tipo -f (file o archivo) -d (directorio) |
-|  | -syze | Filtra los archivos por su tamaño |
-|  | -user, -group | Filtra los archivos por usuario o grupo propietario del archivo |
-| head |  | Permite ver hasta las primeras 10 líneas de texto de un archivo |
-|  | -n o -lines | Nos imprime un numero de lineas personalizado (hasta 10) |
-| tail |  | Permite ver las últimas 10 líneas de texto de un archivo |
-|  | -n o -lines | Nos permite ver un numero de lineas personalizado
-(hasta 10) |
-| cat |  | Concatena y escribe contenido de los archivos en su salida estándar, también se puede usar para el contenido de los archivos |
-| cp |  | Copia archivos o directorios y su contenido.
-Se coloca el nombre del archivo a copiar y el directorio destino 
-cp nombrearchivo.txt /inicio/nombredeusuario/Documentos |
-| mv |  | Mueve uno o mas archivos o directorio y su contenido a otro directorio
-Se coloca el nombre del archivo a mover y el directorio destino 
-mv nombrearchivo.txt /inicio/nombredeusuario/Documentos. |
-| rm |  | Se utiliza para eliminar un archivo o directorio del sistema |
-|  | -i | Pide confirmación del sistema antes de borrar un archivo |
-|  | -f | Permite al sistema eliminar sin confirmacion |
-|  | -r | Borra archivos y directorios de forma recursivas |
-| touch |  | Crea un archivo en blanco |
-| grep |  | Permite conseguir una palabra dentro de todo el archivo en especifico |
-| mkdir |  | Crea un directorio |
-| chmod |  | Modifica los permisos de lectura, escritura y ejecución de un archivo o directorio. |
-| chown |  | Cambia la propiedad de un archivo, directorio o enlace simbólico a un nombre de usuario específico. |
-| kill |  | terminar manualmente un proceso que no responde. |
-| sudo |  | Ejecutar un comando como superusuario 
-Se pedirá contraseña para confirmar |
+| `pwd` | | Imprime el directorio actual de trabajo |
+| `cd` | | Cambia el directorio de trabajo |
+| `ls` | | Lista el contenido del directorio |
+| | `-R` | Lista todos los archivos dentro de los subdirectorios de forma recursiva |
+| | `-a` | Muestra todos los archivos, incluidos los ocultos |
+| | `-la` | Muestra información detallada de los archivos y directorios (formato largo) |
+| `find` | | Busca archivos dentro de un directorio según diferentes criterios |
+| | `-iname` | Busca archivos por nombre (insensible a mayúsculas/minúsculas) |
+| | `-type` | Filtra por tipo: `-type f` (archivo) o `-type d` (directorio) |
+| | `-size` | Filtra los archivos por su tamaño |
+| | `-user`, `-group` | Filtra los archivos por usuario o grupo propietario |
+| `head` | | Muestra las primeras 10 líneas de un archivo por defecto |
+| | `-n N` | Muestra las primeras N líneas (sin límite superior fijo) |
+| `tail` | | Muestra las últimas 10 líneas de un archivo por defecto |
+| | `-n N` | Muestra las últimas N líneas (sin límite superior fijo) |
+| `cat` | | Concatena y muestra el contenido de uno o varios archivos en la salida estándar |
+| `cp` | | Copia archivos o directorios. Ejemplo: `cp archivo.txt /home/usuario/Documentos` |
+| `mv` | | Mueve o renombra archivos y directorios. Ejemplo: `mv archivo.txt /home/usuario/Documentos` |
+| `rm` | | Elimina un archivo o directorio del sistema |
+| | `-i` | Pide confirmación antes de borrar |
+| | `-f` | Elimina sin pedir confirmación |
+| | `-r` | Borra directorios y su contenido de forma recursiva |
+| `touch` | | Crea un archivo vacío o actualiza la fecha de modificación de uno existente |
+| `grep` | | Busca un patrón de texto dentro de uno o varios archivos |
+| `mkdir` | | Crea un directorio |
+| `chmod` | | Modifica los permisos de lectura, escritura y ejecución de un archivo o directorio |
+| `chown` | | Cambia el propietario de un archivo, directorio o enlace simbólico |
+| `kill` | | Envía una señal a un proceso (por defecto SIGTERM para terminarlo) |
+| `sudo` | | Ejecuta un comando con privilegios de superusuario (pedirá contraseña) |
 
 ## Gestión de permisos de archivos y directorios
 
@@ -126,32 +120,37 @@ Otra forma de hacer la gestión de permisos de usuario en linux es por sus octet
 
 Cada permiso tiene una cantidad:
 
-- r-4
-- w-2
-- x-1
+- `r` = 4
+- `w` = 2
+- `x` = 1
 
-Si sumamos los permisos daría 7. Para hacer la asignación tenemos que sumar los números de los permisos que queremos otorgar
+Para asignar permisos, se suman los valores de los permisos deseados para cada grupo (propietario, grupo, otros):
 
-- 7 = rwx
-- 6 = rw-
-- 5 = r-x
-- 4 = r–
-- 3 = -wx
-- 2 = -w-
-- 1 = –x
+- 7 = `rwx` (4+2+1)
+- 6 = `rw-` (4+2)
+- 5 = `r-x` (4+1)
+- 4 = `r--` (4)
+- 3 = `-wx` (2+1)
+- 2 = `-w-` (2)
+- 1 = `--x` (1)
+- 0 = `---` (sin permisos)
 
-Todos los permisos lo podemos cambiar con el comando chmod seguido de los octetos y o permisos que queramos otorgar:
-
-**chmod 437 file**
-
-esto se resume a otorgar permiso de lectura al usuario propietario, premios de lectura y ejecución al resto de los usuarios del grupo y permiso de lectura, escritura al resto de los usuarios del sistema
+Todos los permisos se pueden cambiar con el comando `chmod` seguido de los tres dígitos octales:
 
 ```bash
-r---wxrwx 1 user group 0 sep 17 10:53 file
+chmod 755 script.sh
 ```
 
-## 💡Laboratorio: Comando básico de navegación y manipulación de archivos y directorios
+Esto asigna al propietario permisos de lectura, escritura y ejecución (`rwx` = 7), y al grupo y a otros usuarios permisos de lectura y ejecución (`r-x` = 5):
 
-Abrimos nuestro intérprete de comandos y comienza a explorar por los distintos comandos básicos que les dejamos. 
+```bash
+-rwxr-xr-x 1 user group 0 sep 17 10:53 script.sh
+```
 
-Sientete libre tambien de experimentar con la asignacion de permisos a usuario y archivos 
+Otro ejemplo habitual es `chmod 644`, que se usa comúnmente para archivos regulares: lectura y escritura para el propietario, solo lectura para grupo y otros.
+
+## Laboratorio: Comandos básicos de navegación y manipulación de archivos y directorios
+
+Abre tu intérprete de comandos y experimenta con los distintos comandos básicos que hemos visto.
+
+Practica también con la asignación de permisos a usuarios y archivos.

--- a/02-linux/command-line-fundamentals.es.md
+++ b/02-linux/command-line-fundamentals.es.md
@@ -39,37 +39,18 @@ Algunas Shells CLI que frecuentemente conseguimos son:
 
 ## Comandos básicos de navegación y manipulación de archivos y directorios
 
-Estos son varios comandos básicos que te ayudarán a navegar en la terminal.
+En la lección de [Archivos y directorios](./files-directories.es.md) vimos los comandos fundamentales para navegar y manipular el sistema de archivos: `pwd`, `cd`, `ls`, `cat`, `head`, `tail`, `cp`, `mv`, `rm`, `touch` y `mkdir`. Aquí ampliamos con comandos adicionales que complementan el trabajo en la terminal.
 
 Las *flags* son opciones que se pasan a los comandos para obtener un resultado más específico.
 
 | Comando | Flags | Función |
 | --- | --- | --- |
-| `pwd` | | Imprime el directorio actual de trabajo |
-| `cd` | | Cambia el directorio de trabajo |
-| `ls` | | Lista el contenido del directorio |
-| | `-R` | Lista todos los archivos dentro de los subdirectorios de forma recursiva |
-| | `-a` | Muestra todos los archivos, incluidos los ocultos |
-| | `-la` | Muestra información detallada de los archivos y directorios (formato largo) |
 | `find` | | Busca archivos dentro de un directorio según diferentes criterios |
 | | `-iname` | Busca archivos por nombre (insensible a mayúsculas/minúsculas) |
 | | `-type` | Filtra por tipo: `-type f` (archivo) o `-type d` (directorio) |
 | | `-size` | Filtra los archivos por su tamaño |
 | | `-user`, `-group` | Filtra los archivos por usuario o grupo propietario |
-| `head` | | Muestra las primeras 10 líneas de un archivo por defecto |
-| | `-n N` | Muestra las primeras N líneas (sin límite superior fijo) |
-| `tail` | | Muestra las últimas 10 líneas de un archivo por defecto |
-| | `-n N` | Muestra las últimas N líneas (sin límite superior fijo) |
-| `cat` | | Concatena y muestra el contenido de uno o varios archivos en la salida estándar |
-| `cp` | | Copia archivos o directorios. Ejemplo: `cp archivo.txt /home/usuario/Documentos` |
-| `mv` | | Mueve o renombra archivos y directorios. Ejemplo: `mv archivo.txt /home/usuario/Documentos` |
-| `rm` | | Elimina un archivo o directorio del sistema |
-| | `-i` | Pide confirmación antes de borrar |
-| | `-f` | Elimina sin pedir confirmación |
-| | `-r` | Borra directorios y su contenido de forma recursiva |
-| `touch` | | Crea un archivo vacío o actualiza la fecha de modificación de uno existente |
 | `grep` | | Busca un patrón de texto dentro de uno o varios archivos |
-| `mkdir` | | Crea un directorio |
 | `chmod` | | Modifica los permisos de lectura, escritura y ejecución de un archivo o directorio |
 | `chown` | | Cambia el propietario de un archivo, directorio o enlace simbólico |
 | `kill` | | Envía una señal a un proceso (por defecto SIGTERM para terminarlo) |

--- a/02-linux/files-directories.es.md
+++ b/02-linux/files-directories.es.md
@@ -9,9 +9,9 @@ authors:
   - blindma1den
   - lorenagubaira
 description: >-
-  Master file and directory management in Linux! Learn essential commands and
-  best practices for navigating and manipulating files efficiently. Discover
-  more!
+  Domina la gestión de archivos y directorios en Linux. Aprende los comandos
+  esenciales y las mejores prácticas para navegar y manipular archivos de
+  forma eficiente.
 ---
 ## Navegación y manipulación de archivos y directorios.
 
@@ -21,33 +21,27 @@ Para comenzar, es importante comprender la estructura de directorios. El sistema
 
 Dentro de los comandos básicos tenemos:
 
-| Comando | Flags | Funcion |
+| Comando | Flags | Función |
 | --- | --- | --- |
-| pwd |  | Imprime el directorio actual de trabajo |
-| cd |  | Cambiar el directorio de trabajo |
-| ls |  | Listar contenido del directorio |
-|  | -R | Listara todos los archivos dentro de los subdirectorios |
-|  | -a | Mostrará todos los archivos ocultos |
-|  | -al | Mostrará la información detallada de los archivos y directorios |
-| head |  | Permite ver hasta las primeras 10 lineas de texto de un archivo |
-|  | -n o -lines | Nos imprime un numero de lineas personalizado (hasta 10) |
-| tail |  | Permite ver las ultimas 10 lineas de texto de un archivo |
-|  | -n o -lines | Nos permite ver un numero de lineas personalizado |
-| (hasta 10) |  |  |
-| cat |  | Concatena y escribe contenido de los archivos en su salida estanadar, tambien se puede usar para el contenido de los archivos |
-| cp |  | Copia archivos o directorios y su contenido. |
-| Se coloca el nombre del archivo a copiar y el directorio destino |  |  |
-| cp nombrearchivo.txt /inicio/nombredeusuario/Documentos |  |  |
-| mv |  | Mueve uno o mas archivos o directorio y su contenido a otro directorio |
-| Se coloca el nombre del archivo a mover y el directorio destino |  |  |
-| mv nombrearchivo.txt /inicio/nombredeusuario/Documentos. |  |  |
-| rm |  | Se utiliza para eliminar un archivo o directorio del sistema |
-|  | -i | Pide confirmacion del sistema antes de borrar un archivo |
-|  | -f | Permite al sistema eliminar sin confirmación |
-|  | -r | Borra archivos y directorios de forma recursivas |
-| touch |  | Crea un archivo en blanco |
-| mkdir |  | Crea un directorio |
-|  |  |  |
+| `pwd` | | Imprime el directorio actual de trabajo |
+| `cd` | | Cambia el directorio de trabajo |
+| `ls` | | Lista el contenido del directorio |
+| | `-R` | Lista todos los archivos dentro de los subdirectorios de forma recursiva |
+| | `-a` | Muestra todos los archivos, incluidos los ocultos |
+| | `-la` | Muestra información detallada de los archivos y directorios |
+| `head` | | Muestra las primeras 10 líneas de un archivo por defecto |
+| | `-n N` | Muestra las primeras N líneas |
+| `tail` | | Muestra las últimas 10 líneas de un archivo por defecto |
+| | `-n N` | Muestra las últimas N líneas |
+| `cat` | | Concatena y muestra el contenido de archivos en la salida estándar |
+| `cp` | | Copia archivos o directorios. Ejemplo: `cp archivo.txt /home/usuario/Documentos` |
+| `mv` | | Mueve o renombra archivos y directorios. Ejemplo: `mv archivo.txt /home/usuario/Documentos` |
+| `rm` | | Elimina un archivo o directorio del sistema |
+| | `-i` | Pide confirmación antes de borrar |
+| | `-f` | Elimina sin pedir confirmación |
+| | `-r` | Borra directorios y su contenido de forma recursiva |
+| `touch` | | Crea un archivo vacío o actualiza la fecha de modificación de uno existente |
+| `mkdir` | | Crea un directorio |
 
 > ⚠️ Es importante tener precaución al utilizar comandos de manipulación de archivos y directorios, ya que las acciones son irreversibles y pueden afectar los datos de manera permanente. Siempre asegúrate de tener copias de seguridad actualizadas y de verificar dos veces antes de ejecutar comandos que puedan tener consecuencias no deseadas.
 
@@ -92,13 +86,13 @@ Existen dos formas de asignar permisos:
 - `u`: usuario
 - `g`: grupo
 - `o`: otros
-- `a:` todos (all), si necesitas aplicar el mismo permiso a usuario, grupos y otros, usa «a» para ahorrar tiempo.
+- `a`: todos (all), si necesitas aplicar el mismo permiso a usuario, grupos y otros, usa `a` para ahorrar tiempo.
 
 Luego agregamos si queremos añadir o quitar permisos
 
-- `+:` añadir permisos
-- `:` quitar permisos
-- `=:` especifica los permisos fijados.
+- `+`: añadir permisos
+- `-`: quitar permisos
+- `=`: especifica los permisos fijados.
 
 Y después colocamos los permisos que queremos asignar
 
@@ -108,7 +102,7 @@ Y después colocamos los permisos que queremos asignar
 
 ![otorgando persmisos](https://github.com/4GeeksAcademy/cybersecurity-syllabus/blob/main/assets/linux-image37.jpg?raw=true)
 
-Según esta imagen tenemos un directorio IT y adentro hay un archivo llamado `script.sh`, el cual tiene permisos de lectura pero no de escritura ni de ejecucion para el grupo propietario , esto lo podemos cambiar usando el comando `chmod` y asignando los permisos mediante números basados en e formato octal de permisos de linux
+Según esta imagen tenemos un directorio IT y adentro hay un archivo llamado `script.sh`, el cual tiene permisos de lectura pero no de escritura ni de ejecución para el grupo propietario. Esto lo podemos cambiar usando el comando `chmod` y asignando los permisos mediante números basados en el formato octal de permisos de Linux
 
 ![como ver permisos en linux](https://github.com/4GeeksAcademy/cybersecurity-syllabus/blob/main/assets/linux-image38.jpg?raw=true)
 
@@ -124,9 +118,9 @@ Podemos realizar el mismo ejercicio anterior, esta vez cambiaremos los permisos 
 
 ![permisos de forma octal](https://github.com/4GeeksAcademy/cybersecurity-syllabus/blob/main/assets/linux-image39.jpg?raw=true)
 
-- Otro comando que aprenderemos es el `mkdir` el cual nos permitirá crear un directorio
-- `chown` nos permitirá cambiar el propietario del archivo o directorio
-- chgrp nos permitirá cambiar el grupo propietario del archivo o directorio
+- `mkdir`: permite crear un directorio.
+- `chown`: permite cambiar el propietario del archivo o directorio.
+- `chgrp`: permite cambiar el grupo propietario del archivo o directorio.
 
 ## Búsqueda y filtrado de archivos
 
@@ -156,4 +150,4 @@ En este ejemplo, buscamos si dentro del archivo [script.sh](http://script.sh/) h
 
 ### Comando `locate`
 
-Este comando utiliza una base de datos para realizar búsquedas rápidas de archivos en todo el sistema. Este comando se especialmente útil cuando necesitas buscar archivos de forma frecuente y en grandes volúmen
+Este comando utiliza una base de datos indexada para realizar búsquedas rápidas de archivos en todo el sistema. Es especialmente útil cuando necesitas buscar archivos de forma frecuente y en grandes volúmenes. La base de datos se actualiza periódicamente con el comando `updatedb`.

--- a/02-linux/intro-linux-security.es.md
+++ b/02-linux/intro-linux-security.es.md
@@ -43,14 +43,14 @@ La configuración de un cortafuegos y la protección de servicios son aspectos f
 - **Limitar el acceso**: Restringe el acceso a los servicios solo a las direcciones IP o rangos de IP necesarios. Esto ayuda a reducir la superficie de ataque y limitar la exposición a posibles amenazas.
 - **Herramientas de seguridad adicionales**: Además de un cortafuegos, existen otras herramientas de seguridad que se pueden utilizar para proteger los servicios en Linux. Por ejemplo, se pueden implementar sistemas de detección y prevención de intrusiones (IDS/IPS) para monitorear y bloquear actividades sospechosas. También se pueden utilizar herramientas de escaneo de vulnerabilidades para identificar posibles debilidades en los servicios.
 
-## Instalacion de iptables
+## Instalación de iptables
 
 **iptables** es una herramienta de firewall y filtrado de paquetes en sistemas Linux. Permite controlar y configurar las reglas de seguridad de red para proteger tu sistema y controlar el tráfico de red entrante y saliente.
 Con iptables, se puede definir reglas que determinen qué paquetes de red se permiten o bloquean en tu sistema. Estas reglas se basan en criterios como la dirección IP de origen o destino, el puerto de origen o destino, el protocolo utilizado y otras características de los paquetes.
 Las reglas de iptables se organizan en tablas, y cada tabla contiene cadenas de reglas. Las tablas más comunes son "filter", que se utiliza para filtrar paquetes, y "nat", que se utiliza para realizar traducción de direcciones de red (NAT).
 Dentro de cada tabla, hay diferentes cadenas predefinidas, como "INPUT" para el tráfico entrante, "OUTPUT" para el tráfico saliente y "FORWARD" para el tráfico que se reenvía a través del sistema. Puedes agregar reglas a estas cadenas para especificar qué hacer con los paquetes que coinciden con esas reglas, como aceptarlos, rechazarlos o redirigirlos.
 
-Para su instalacion debemos:
+Para su instalación debemos:
 
 1. **Verificar si iptables está instalado**
 

--- a/02-linux/intro-linux.es.md
+++ b/02-linux/intro-linux.es.md
@@ -13,13 +13,13 @@ description: >-
 ---
 ## Qué es Linux y su importancia en el mundo de la informática
 
-A pesar de a lo que generalmente puedas escuchar sobre linux, este en realidad se trata de un núcleo o **kernel** que puede controlar a un hardware, una manera más sencilla de explicarlo es que Linux es un conjuntos de drivers necesarios para usar un dispositivo como una computadora o una laptop. Este se creó como un núcleo semejante al de un sistema operativo UNIX.
+A pesar de lo que generalmente se escucha sobre Linux, en realidad se trata de un **kernel** (núcleo) que actúa como intermediario entre el hardware y el software de usuario. De forma simplificada, Linux es el componente que gestiona los recursos del hardware — CPU, memoria, dispositivos — y permite que los programas se ejecuten sobre él. Fue diseñado siguiendo los principios del sistema operativo UNIX.
 
-Este núcleo fue desarrollado con Linus Torvalds cuando en 1991 comenzó a trabajar con unas ideas para un núcleo de un sistema operativo gratuito similar a unix, por lo que tomó como base el sistema Minix como un clon de Unix e hizo un núcleo monolítico y así con ayuda de colaboradores, sacar la primera versión linux 0.01.
+Este núcleo fue desarrollado por Linus Torvalds, quien en 1991 comenzó a trabajar en un núcleo de sistema operativo gratuito inspirado en UNIX. Tomó como referencia MINIX (un sistema educativo creado por Andrew S. Tanenbaum) y desarrolló un núcleo monolítico. Con la ayuda de colaboradores a través de Internet, publicó la primera versión, Linux 0.01.
 
-Actualmente Linux es un núcleo monolítico híbrido con controladores de dispositivos y extensiones del núcleo que normalmente se ejecutan en un espacio privilegiado conocido como anillo 0, con acceso irrestricto al hardware, aunque algunos se ejecutan en espacio de usuario.
+Actualmente Linux es un núcleo monolítico con soporte para módulos cargables. Los controladores de dispositivos y las extensiones del núcleo normalmente se ejecutan en un espacio privilegiado conocido como anillo 0 (*ring 0*), con acceso irrestricto al hardware, aunque algunos controladores pueden ejecutarse en espacio de usuario.
 
-En 1992 los desarrolladores del núcleo Linux, comenzaron a trabajar con el proyecto GNU, desarrollado por Richard Stallman en 1983 y así crear GNU/Linux, una familia de sistemas operativos tipo Unix compuesto por software libre y de código abierto buscando una solución de libre distribución de los sistemas operativos frustrado por la concesión de licencias de uso que utilizaba MINIX.
+En 1992, el núcleo Linux se combinó con las herramientas del proyecto GNU, iniciado por Richard Stallman en 1983. El proyecto GNU buscaba crear un sistema operativo completo de software libre, pero carecía de un núcleo funcional. La unión de ambos proyectos dio lugar a GNU/Linux, una familia de sistemas operativos tipo UNIX compuestos por software libre y de código abierto.
 
 Entre los componentes que tenemos dentro del sistema GNU/Linux podemos conseguir:
 
@@ -31,24 +31,24 @@ Entre los componentes que tenemos dentro del sistema GNU/Linux podemos conseguir
 
 ## Diferencias entre Linux y otros sistemas operativos
 
-Linux a diferencia de Windows, es multitarea real, y multiusuario, posee un esquema de seguridad basado en usuarios y permisos de lectura, escritura y ejecución establecidos a los archivos y directorios. Esto significa que cada usuario es propietario de sus archivos, y otro usuario no puede acceder a estos archivos. Esta propiedad no permite el contagio de virus entre archivos de diferentes usuarios.
+Linux es un sistema multitarea real y multiusuario. Posee un esquema de seguridad basado en usuarios y permisos de lectura, escritura y ejecución asignados a archivos y directorios. Cada usuario es propietario de sus archivos y, por defecto, otros usuarios no pueden acceder a ellos. Este modelo de permisos reduce significativamente la propagación de malware entre cuentas de usuario, aunque no la elimina por completo.
 
 | Característica | Windows | Linux |
 | --- | --- | --- |
-| Tipo de sistema operativo | Comercial (se vende y se compra) | Código abierto, descargable y modificable de forma gratuita |
-| Estabilidad | Poco estable | Más estable |
-| Interfaz gráfica | Alta tecnología pero poco estable | Variedad de interfaces, manejo más complejo |
-| Apto para principiantes | Sí, gracias a interfaces gráficas intuitivas | Más complejo, requiere familiaridad con la línea de comandos |
-| Seguridad | Frecuentes fallos de seguridad y vulnerabilidades | Raramente amenazado por fallos de seguridad |
-| Actualizaciones | Sencillas y automatizadas | En ocasiones pueden ser complejas |
+| Tipo de sistema operativo | Comercial (licencia de pago) | Núcleo de código abierto, distribuciones gratuitas y comerciales |
+| Estabilidad | Estable en versiones recientes (Windows 10/11, Server) | Alta estabilidad, especialmente en servidores |
+| Interfaz gráfica | Interfaz unificada y pulida | Variedad de entornos de escritorio (GNOME, KDE, XFCE, etc.) |
+| Apto para principiantes | Sí, interfaz gráfica intuitiva | Distribuciones como Ubuntu facilitan la entrada, pero el dominio requiere línea de comandos |
+| Seguridad | Modelo de permisos mejorado desde Vista/UAC; mayor superficie de ataque por cuota de mercado | Modelo de permisos robusto por defecto; menor superficie de ataque en escritorio, no invulnerable |
+| Actualizaciones | Automatizadas vía Windows Update | Gestores de paquetes potentes (`apt`, `dnf`, `pacman`), actualizaciones controladas por el usuario |
 
 ### Ventajas y beneficios de utilizar Linux
 
 El hecho de que es *software libre*, es decir, que junto con el sistema, se puede obtener el código fuente de cualquier parte del mismo y modificarlo a gusto. Ésto da varias ventajas, por ejemplo:
 
-- La seguridad de saber *qué hace* un programa tan solo viendo el código fuente, o en su defecto, tener la seguridad que al estar el código disponible,
-- La libertad que provee la licencia GPL permite a cualquier programador modificar y mejorar cualquier parte del sistema, ésto da como resultado que la calidad del software incluido en GNU/Linux sea muy buena.
-- El hecho de que el sistema sea mantenido por una gran comunidad de programadores y usuarios alrededor del mundo, provee una gran velocidad de respuesta ante errores de programas que se van descubriendo, que ninguna compañía comercial de software puede igualar.
+- La posibilidad de auditar *qué hace* un programa inspeccionando su código fuente, lo que aumenta la transparencia y la confianza en el software.
+- La licencia GPL permite a cualquier desarrollador modificar y mejorar cualquier parte del sistema, lo que contribuye a una alta calidad del software incluido en GNU/Linux.
+- El mantenimiento por una gran comunidad de programadores y usuarios alrededor del mundo permite una respuesta rápida ante errores y vulnerabilidades descubiertos.
 
 Además de las ventajas anteriormente enumeradas, GNU/Linux es ideal para su utilización en un ambiente de trabajo, dos razones justifican esto:
 

--- a/02-linux/software-package-management.es.md
+++ b/02-linux/software-package-management.es.md
@@ -6,8 +6,8 @@ authors:
   - blindma1den
   - lorenagubaira
 description: >-
-  Master Linux package management! Learn to install, update, and remove software
-  effortlessly while keeping your system secure. Discover more now!
+  Aprende a gestionar paquetes en Linux. Instala, actualiza y elimina software
+  de forma eficiente manteniendo tu sistema seguro.
 ---
 Hemos hablado previamente sobre el uso de gestores de paquetes y cómo nos pueden ayudar a instalar aplicaciones y actualizar software, recordemos que en el entorno de los servidores Linux, los gestores de paquetes son herramientas fundamentales para la gestión eficiente del software ya que simplifican la instalación, actualización y eliminación de paquetes de software en un servidor, lo que resulta esencial para mantener el sistema actualizado y seguro.
 
@@ -52,13 +52,13 @@ Debajo encontraremos una lista con otros manejadores de paquetes:
 
 Una gran cantidad de las vulnerabilidades de un computador ocurren debido a software y paquetes desactualizados. Cuando una vulnerabilidad en un paquete es detectada, los desarrolladores proceden a corregirla y luego proceden a publicar una nueva versión del paquete. Es importante estar al dia.
 
-Una de las ventajas clave de utilizar gestores de paquetes en servidores Linux es la capacidad de mantener el software actualizado de manera sencilla. Con un simple comando, como `sudo apt-get update` en apt-get o `sudo yum update" en yum, puedes verificar si hay actualizaciones disponibles para los paquetes instalados en el servidor. Luego, puedes ejecutar "sudo apt-get upgrade" o "sudo yum upgrade" para instalar las actualizaciones. Esto garantiza que el software esté actualizado y protegido contra vulnerabilidades conocidas.
+Una de las ventajas clave de utilizar gestores de paquetes en servidores Linux es la capacidad de mantener el software actualizado de manera sencilla. Con un simple comando, como `sudo apt-get update` en apt-get o `sudo yum update` en yum, puedes verificar si hay actualizaciones disponibles para los paquetes instalados en el servidor. Luego, puedes ejecutar `sudo apt-get upgrade` o `sudo yum upgrade` para instalar las actualizaciones. Esto garantiza que el software esté actualizado y protegido contra vulnerabilidades conocidas.
 
-Además, los gestores de paquetes en servidores Linux también permiten la eliminación de software de manera eficiente. Si ya no necesitas un paquete, puedes utilizar el comando correspondiente para desinstalarlo. Por ejemplo, "sudo apt-get remove nombre_paquete" en apt-get o "sudo yum remove nombre_paquete" en yum. Esto asegura una limpieza adecuada del sistema y evita la acumulación de software innecesario.
+Además, los gestores de paquetes en servidores Linux también permiten la eliminación de software de manera eficiente. Si ya no necesitas un paquete, puedes utilizar el comando correspondiente para desinstalarlo. Por ejemplo, `sudo apt-get remove nombre_paquete` en apt-get o `sudo yum remove nombre_paquete` en yum. Esto asegura una limpieza adecuada del sistema y evita la acumulación de software innecesario.
 
 ## Utilizando el manejador apt
 
-Para la explicación usaremos el gestor de paquetes `apt` siempre con el siguiente formato para los commandos:
+Para la explicación usaremos el gestor de paquetes `apt` siempre con el siguiente formato para los comandos:
 
 ```bash
 sudo apt <parámetros> <nombre del paquete or programa>
@@ -66,11 +66,11 @@ sudo apt <parámetros> <nombre del paquete or programa>
 
 En nuestro servidor ubuntu probaremos nuestro gestor de paquete de software actualizando e instalando un software.
 
-1. Primero usaremos el comando `sudo apt update` que se encargara de traer todas las aplicaciones que tengamos en el sistema.
+1. Primero usaremos el comando `sudo apt update` que se encargará de actualizar la lista de paquetes disponibles desde los repositorios configurados.
 
 ![apt-update](https://github.com/4GeeksAcademy/cybersecurity-syllabus/blob/main/assets/linux-apt-update-69.jpg?raw=true) 
 
-1. Una vez actualizado los paquetes, procedemos instalar las actualizaciones con el comando `sudo apt upgrade`.
+2. Una vez actualizada la lista de paquetes, procedemos a instalar las actualizaciones con el comando `sudo apt upgrade`.
 
 ![apt upgrade](https://github.com/4GeeksAcademy/cybersecurity-syllabus/blob/main/assets/manejo-de-paquetes-70.jpg?raw=true)
 
@@ -94,24 +94,24 @@ sudo apt install -y <paquete1> <paquete2>
 
 La búsqueda y eliminación de paquetes en Linux es una tarea común para los administradores de sistemas ya que a veces, es necesario encontrar un paquete específico o eliminar uno que ya no se necesita, afortunadamente, Linux cuenta con herramientas poderosas que facilitan estas tareas.
 
-Para buscar paquetes en Linux, puedes utilizar el gestor de paquetes específico de tu distribución. Por ejemplo, en distribuciones basadas en Debian y Ubuntu, como Ubuntu puedes utilizar el comando "apt-cache search término_de_búsqueda" con el gestor de paquetes apt-get. Esto buscará en los repositorios disponibles y mostrará una lista de paquetes que coincidan con el término de búsqueda. Puedes refinar la búsqueda utilizando expresiones regulares o palabras clave más específicas.
+Para buscar paquetes en Linux, puedes utilizar el gestor de paquetes específico de tu distribución. Por ejemplo, en distribuciones basadas en Debian y Ubuntu, puedes utilizar el comando `apt-cache search término_de_búsqueda`. Esto buscará en los repositorios disponibles y mostrará una lista de paquetes que coincidan con el término de búsqueda. Puedes refinar la búsqueda utilizando expresiones regulares o palabras clave más específicas.
 
-![administracionDeServidores-parte1%20ab5924e8fe3644549acdf70f4425a531/image73.png](administracionDeServidores-parte1%20ab5924e8fe3644549acdf70f4425a531/image73.png)
+<!-- Imagen eliminada: la ruta original era local y no se resolvía correctamente -->
 
 
-En distribuciones como Red Hat y CentOS, que utilizan el gestor de paquetes yum, puedes utilizar el comando "yum search término_de_búsqueda" para buscar paquetes. Al igual que con apt-get, esto mostrará una lista de paquetes que coincidan con el término de búsqueda en los repositorios disponibles.
+En distribuciones como Red Hat y CentOS, que utilizan el gestor de paquetes yum, puedes utilizar el comando `yum search término_de_búsqueda` para buscar paquetes. Al igual que con apt-get, esto mostrará una lista de paquetes que coincidan con el término de búsqueda en los repositorios disponibles.
 
 ![apt-cache search mysql](https://github.com/4GeeksAcademy/cybersecurity-syllabus/blob/main/assets/manejo-de-paquetes-73.jpg?raw=true)
 
-Además de los gestores de paquetes, también puedes utilizar herramientas adicionales para buscar paquetes en Linux. Por ejemplo, puedes utilizar el comando "dpkg -l | grep término_de_búsqueda" en distribuciones basadas en Debian para buscar paquetes instalados localmente. Esto mostrará una lista de paquetes que coincidan con el término de búsqueda.
+Además de los gestores de paquetes, también puedes utilizar herramientas adicionales para buscar paquetes en Linux. Por ejemplo, puedes utilizar el comando `dpkg -l | grep término_de_búsqueda` en distribuciones basadas en Debian para buscar paquetes instalados localmente. Esto mostrará una lista de paquetes que coincidan con el término de búsqueda.
 
 ![dpkg grep mysql](https://github.com/4GeeksAcademy/cybersecurity-syllabus/blob/main/assets/manejo-de-paquetes-75.jpg?raw=true)
 
-Una vez que hayas encontrado el paquete que deseas eliminar, puedes utilizar el gestor de paquetes correspondiente para eliminarlo. En distribuciones basadas en Debian y Ubuntu, puedes utilizar el comando "sudo apt-get remove nombre_paquete" con apt-get. Esto eliminará el paquete y todos sus archivos asociados del sistema.
+Una vez que hayas encontrado el paquete que deseas eliminar, puedes utilizar el gestor de paquetes correspondiente para eliminarlo. En distribuciones basadas en Debian y Ubuntu, puedes utilizar el comando `sudo apt-get remove nombre_paquete`. Esto eliminará el paquete y todos sus archivos asociados del sistema.
 
-En distribuciones como Red Hat y CentOS, puedes utilizar el comando "sudo yum remove nombre_paquete" con yum para eliminar un paquete. Al igual que con apt-get, esto eliminará el paquete y sus archivos asociados.
+En distribuciones como Red Hat y CentOS, puedes utilizar el comando `sudo yum remove nombre_paquete` para eliminar un paquete. Al igual que con apt-get, esto eliminará el paquete y sus archivos asociados.
 
-Si deseas eliminar completamente un paquete, incluidos los archivos de configuración, puedes utilizar el comando "sudo apt-get purge nombre_paquete" en distribuciones basadas en Debian y Ubuntu, o "sudo yum remove nombre_paquete" en distribuciones como Red Hat y CentOS.
+Si deseas eliminar completamente un paquete, incluidos los archivos de configuración, puedes utilizar el comando `sudo apt-get purge nombre_paquete` en distribuciones basadas en Debian y Ubuntu, o `sudo yum remove nombre_paquete` en distribuciones como Red Hat y CentOS.
 
 Es importante tener en cuenta que al eliminar un paquete, es posible que se eliminen también otros paquetes que dependan de él. El gestor de paquetes te informará sobre los cambios que se realizarán antes de proceder con la eliminación.
 


### PR DESCRIPTION
## What

Comprehensive review of `02-linux/` Spanish content (`.es.md` files).

## Changes

- Fix historical and technical inaccuracies in Linux intro (kernel dates, distro facts)
- Fix broken command table and chmod numeric examples in CLI fundamentals
- Fix broken table and typos in files-directories lesson
- Fix formatting and broken image reference in package management
- Fix missing accents in security headings (iptables section)
- Replace deprecated ifconfig with ip command and fix TTL misconception

## Why

Fixes factual errors (wrong dates, deprecated tools presented as current), broken markdown rendering (malformed tables, dead image links), and missing diacritical marks that affect readability in Spanish.

## Files

- `02-linux/intro-linux.es.md`
- `02-linux/command-line-fundamentals.es.md`
- `02-linux/files-directories.es.md`
- `02-linux/software-package-management.es.md`
- `02-linux/intro-linux-security.es.md`
- `02-linux/basic-system-administration.es.md`